### PR TITLE
コンテスト名が"◉"となってしまうバグへの対処

### DIFF
--- a/src/atcoder/contest.rs
+++ b/src/atcoder/contest.rs
@@ -24,7 +24,7 @@ pub(super) fn scrape(html: &str) -> Result<Vec<AtCoderContest>> {
             let start = start.timestamp() as u64;
 
             let contest = tds.next().ok_or_else(|| Error::HtmlParseError)?;
-            let contest_title = contest.text().next().ok_or_else(|| Error::HtmlParseError)?;
+            let contest_title = contest.select(&Selector::parse("a").unwrap()).next().ok_or_else(|| Error::HtmlParseError)?.text().next().unwrap();
             let contest_link = contest
                 .select(&Selector::parse("a").unwrap())
                 .next()

--- a/src/atcoder/contest.rs
+++ b/src/atcoder/contest.rs
@@ -24,7 +24,7 @@ pub(super) fn scrape(html: &str) -> Result<Vec<AtCoderContest>> {
             let start = start.timestamp() as u64;
 
             let contest = tds.next().ok_or_else(|| Error::HtmlParseError)?;
-            let contest_title = contest.select(&Selector::parse("a").unwrap()).next().ok_or_else(|| Error::HtmlParseError)?.text().next().unwrap();
+            let contest_title = contest.select(&Selector::parse("a").unwrap()).next().ok_or_else(|| Error::HtmlParseError)?.text().next().ok_or_else(|| Error::HtmlParseError)?;
             let contest_link = contest
                 .select(&Selector::parse("a").unwrap())
                 .next()

--- a/test_resources/contests
+++ b/test_resources/contests
@@ -12,43 +12,38 @@
 	<meta name="google-site-verification" content="nXGC_JxO0yoP1qBzMnYD_xgufO6leSLw1kyNo2HZltM" />
 
 	
-	<meta name="description" content="プログラミング初級者から上級者まで楽しめる、プログラミングコンテストサイト「AtCoder」。オンラインで毎週開催プログラミングコンテストを開催しています。競技プログラミングを用いて、客観的に自分のスキルを計ることのできるサービスです。">
+	<meta name="description" content="プログラミング初級者から上級者まで楽しめる、競技プログラミングコンテストサイト「AtCoder」。オンラインで毎週開催プログラミングコンテストを開催しています。競技プログラミングを用いて、客観的に自分のスキルを計ることのできるサービスです。">
 	<meta name="author" content="AtCoder Inc.">
 	<link rel="canonical" href="https://atcoder.jp/">
 
 	<meta property="og:site_name" content="AtCoder">
 	
 	<meta property="og:title" content="過去のコンテスト - AtCoder" />
-	<meta property="og:description" content="プログラミング初級者から上級者まで楽しめる、プログラミングコンテストサイト「AtCoder」。オンラインで毎週開催プログラミングコンテストを開催しています。競技プログラミングを用いて、客観的に自分のスキルを計ることのできるサービスです。" />
+	<meta property="og:description" content="プログラミング初級者から上級者まで楽しめる、競技プログラミングコンテストサイト「AtCoder」。オンラインで毎週開催プログラミングコンテストを開催しています。競技プログラミングを用いて、客観的に自分のスキルを計ることのできるサービスです。" />
 	<meta property="og:type" content="website" />
-	<meta property="og:url" content="https://atcoder.jp/contests/archive?lang=ja&amp;page=1" />
+	<meta property="og:url" content="https://atcoder.jp/contests/archive" />
 	<meta property="og:image" content="https://img.atcoder.jp/assets/atcoder.png" />
 	<meta name="twitter:card" content="summary" />
 	<meta name="twitter:site" content="@atcoder" />
 	
 	<meta property="twitter:title" content="過去のコンテスト - AtCoder" />
 
-	<link href='//fonts.googleapis.com/css?family=Lato:400,700' rel='stylesheet' type='text/css'>
-	<link rel="stylesheet" type="text/css" href='/public/css/bootstrap.min.css?v=201906060121'>
-	<link rel="stylesheet" type="text/css" href='/public/css/base.css?v=201906060121'>
+	<link href="//fonts.googleapis.com/css?family=Lato:400,700" rel="stylesheet" type="text/css">
+	<link rel="stylesheet" type="text/css" href="/public/css/bootstrap.min.css?v=201910091808">
+	<link rel="stylesheet" type="text/css" href="/public/css/base.css?v=201910091808">
 	<link rel="shortcut icon" type="image/png" href="//img.atcoder.jp/assets/favicon.png">
 	<link rel="apple-touch-icon" href="//img.atcoder.jp/assets/atcoder.png">
-	<script src='/public/js/lib/jquery-1.9.1.min.js?v=201906060121'></script>
-	<script src='/public/js/lib/bootstrap.min.js?v=201906060121'></script>
+	<script src="/public/js/lib/jquery-1.9.1.min.js?v=201910091808"></script>
+	<script src="/public/js/lib/bootstrap.min.js?v=201910091808"></script>
 	<script src="//cdnjs.cloudflare.com/ajax/libs/js-cookie/2.1.4/js.cookie.min.js"></script>
 	<script src="//cdnjs.cloudflare.com/ajax/libs/moment.js/2.18.1/moment.min.js"></script>
 	<script src="//cdnjs.cloudflare.com/ajax/libs/moment.js/2.18.1/locale/ja.js"></script>
 	<script>
 		var LANG = "ja";
-		var userScreenName = "kenkoooo";
+		var userScreenName = "kakira";
+		var csrfToken = "1x4pxoG+f5ZIcxxkrcsHSqeaXa9YdMQ4QBmWeACfAsI="
 	</script>
-	<script src='/public/js/utils.js?v=201906060121'></script>
-	
-	
-	
-	
-	
-		<script src='/public/js/contest-filter.js?v=201906060121'></script>
+	<script src="/public/js/utils.js?v=201910091808"></script>
 	
 	
 	
@@ -62,8 +57,11 @@
 	
 	
 	
-	<script src='/public/js/base.js?v=201906060121'></script>
-	<script src='/public/js/ga.js?v=201906060121'></script>
+	
+	
+	
+	<script src="/public/js/base.js?v=201910091808"></script>
+	<script src="/public/js/ga.js?v=201910091808"></script>
 </head>
 
 <body>
@@ -80,9 +78,9 @@
 			<div class="collapse navbar-collapse" id="navbar-collapse">
 				<ul class="nav navbar-nav">
 				
-					<li><a href='/'>ホーム</a></li>
-					<li><a href='/contests/'>コンテスト</a></li>
-					<li><a href='/ranking'>ランキング</a></li>
+					<li><a href="/">ホーム</a></li>
+					<li><a href="/contests/">コンテスト</a></li>
+					<li><a href="/ranking">ランキング</a></li>
 				
 				</ul>
 				<ul class="nav navbar-nav navbar-right">
@@ -92,26 +90,28 @@
 							<img src='//img.atcoder.jp/assets/flag-lang/ja.png'> 日本語 <span class="caret"></span>
 						</a>
 						<ul class="dropdown-menu">
-							<li><a href='/contests/archive?lang=ja&amp;page=1'><img src='//img.atcoder.jp/assets/flag-lang/ja.png'> 日本語</a></li>
-							<li><a href='/contests/archive?lang=en&amp;page=1'><img src='//img.atcoder.jp/assets/flag-lang/en.png'> English</a></li>
+							<li><a href="/contests/archive?lang=ja"><img src='//img.atcoder.jp/assets/flag-lang/ja.png'> 日本語</a></li>
+							<li><a href="/contests/archive?lang=en"><img src='//img.atcoder.jp/assets/flag-lang/en.png'> English</a></li>
 						</ul>
 					</li>
 					
 					
 						<li class="dropdown">
 							<a class="dropdown-toggle" data-toggle="dropdown" href="#" role="button" aria-haspopup="true" aria-expanded="false">
-								<span class="glyphicon glyphicon-cog" aria-hidden="true"></span> kenkoooo <span class="caret"></span>
+								<span class="glyphicon glyphicon-cog" aria-hidden="true"></span> kakira <span class="caret"></span>
 							</a>
 							<ul class="dropdown-menu">
-								<li><a href='/users/kenkoooo'><span class="glyphicon glyphicon-user" aria-hidden="true"></span> マイプロフィール</a></li>
+								<li><a href="/users/kakira"><span class="glyphicon glyphicon-user" aria-hidden="true"></span> マイプロフィール</a></li>
 								<li class="divider"></li>
-								<li><a href='/settings'><span class="glyphicon glyphicon-wrench" aria-hidden="true"></span> 基本設定</a></li>
-								<li><a href='/settings/icon'><span class="glyphicon glyphicon-picture" aria-hidden="true"></span> アイコン設定</a></li>
-								<li><a href='/settings/password'><span class="glyphicon glyphicon-lock" aria-hidden="true"></span> パスワードの変更</a></li>
+								<li><a href="/settings"><span class="glyphicon glyphicon-wrench" aria-hidden="true"></span> 基本設定</a></li>
+								<li><a href="/settings/icon"><span class="glyphicon glyphicon-picture" aria-hidden="true"></span> アイコン設定</a></li>
+								<li><a href="/settings/password"><span class="glyphicon glyphicon-lock" aria-hidden="true"></span> パスワードの変更</a></li>
+								<li><a href="/settings/fav"><span class="glyphicon glyphicon-star" aria-hidden="true"></span> お気に入り管理</a></li>
 								
 								
+								
 								<li class="divider"></li>
-								<li><a href='javascript:void(form_logout.submit())'><span class="glyphicon glyphicon-log-out" aria-hidden="true"></span> ログアウト</a></li>
+								<li><a href="javascript:void(form_logout.submit())"><span class="glyphicon glyphicon-log-out" aria-hidden="true"></span> ログアウト</a></li>
 							</ul>
 						</li>
 					
@@ -119,8 +119,8 @@
 			</div>
 		</div>
 	</nav>
-	<form method="POST" name="form_logout" action='/logout?continue=https%3A%2F%2Fatcoder.jp%2Fcontests%2Farchive%3Flang%3Dja%26page%3D1'>
-		<input type="hidden" name="csrf_token" value='QDLLVccskFrqRPh2&#43;1Heg&#43;Qp4tpPYkUod9sCDbgtRbU=' />
+	<form method="POST" name="form_logout" action="/logout?continue=https%3A%2F%2Fatcoder.jp%2Fcontests%2Farchive">
+		<input type="hidden" name="csrf_token" value="1x4pxoG&#43;f5ZIcxxkrcsHSqeaXa9YdMQ4QBmWeACfAsI=" />
 	</form>
 	<div id="main-container" class="container" >
 		
@@ -134,63 +134,66 @@
 	</div>
 	<div class="col-lg-3 col-md-4">
 		<div class="panel panel-default">
-	<div class="panel-heading collapse-heading" data-toggle="collapse" data-target="#collapse-category">
+	<div class="panel-heading collapse-heading" data-toggle="collapse" data-target="#collapse-search">
 		<h3 class="panel-title">
 			過去のコンテストを検索
 			<span class="glyphicon pull-right"></span>
 		</h3>
 	</div>
-	<div id="collapse-category" class="panel-body panel-collapse collapse in">
-		<form action='/contests/archive'>
-			<p class="filter-body-heading"><span>カテゴリ</span></p>
+	<div id="collapse-search" class="panel-body panel-collapse collapse in">
+		<form action="/contests/archive">
+			<p class="filter-body-heading">Rated対象 <span class="small grey"><span class='glyphicon glyphicon-question-sign' aria-hidden='true' data-html='true' data-toggle='tooltip' title="Rating変動の対象となるコンテストを「Ratedなコンテスト」と表します。"></span></span></p>
+			<input type="hidden" name="ratedType">
+			<div id="rated-type-btn-group" class="btn-group-vertical btn-group-sm col-xs-12">
+				<button type="submit" class="btn btn-default" data-rated-type="1"><small class="pull-left">ABCクラス <span class="grey">(Rated対象: ~1999)</span></small></button>
+				<button type="submit" class="btn btn-default" data-rated-type="2"><small class="pull-left">ARCクラス <span class="grey">(Rated対象: ~2799)</span></small></button>
+				<button type="submit" class="btn btn-default" data-rated-type="3"><small class="pull-left">AGCクラス <span class="grey">(Rated対象: All)</span></small></button>
+			</div>
+
+			<hr>
+			<p class="filter-body-heading">カテゴリ</p>
 			<input type="hidden" name="category">
 			<div id="category-btn-group" class="btn-group-vertical btn-group-sm col-xs-12">
-				<button type="submit" class="btn btn-default category-button-submit active" data-category=""><small class="pull-left">全て</small></button>
-				
-					
-						<button type="submit" class="btn btn-default category-button-submit" data-category='1'><small class="pull-left">AtCoder Grand Contest</small></button>
-					
+				<button type="submit" class="btn btn-default active" data-category=""><small class="pull-left">全て</small></button>
 				
 					
 				
 					
 				
 					
-						<button type="submit" class="btn btn-default category-button-submit" data-category='4'><small class="pull-left">AtCoder Regular Contest</small></button>
-					
 				
-					
-						<button type="submit" class="btn btn-default category-button-submit" data-category='5'><small class="pull-left">AtCoder Beginner Contest</small></button>
-					
-				
-					
-						<button type="submit" class="btn btn-default category-button-submit" data-category='6'><small class="pull-left">AtCoder Typical Contest</small></button>
 					
 				
 					
 				
 					
-						<button type="submit" class="btn btn-default category-button-submit" data-category='101'><small class="pull-left">非公式コンテスト(unrated)</small></button>
+						<button type="submit" class="btn btn-default" data-category="6"><small class="pull-left">AtCoder Typical Contest</small></button>
 					
 				
 					
 				
 					
-						<button type="submit" class="btn btn-default category-button-submit" data-category='200'><small class="pull-left">JOI過去問</small></button>
+						<button type="submit" class="btn btn-default" data-category="101"><small class="pull-left">非公式コンテスト(unrated)</small></button>
 					
 				
 					
 				
 					
-						<button type="submit" class="btn btn-default category-button-submit" data-category='1000'><small class="pull-left">企業コンテスト本番</small></button>
+						<button type="submit" class="btn btn-default" data-category="200"><small class="pull-left">JOI過去問</small></button>
 					
 				
 					
-						<button type="submit" class="btn btn-default category-button-submit" data-category='1001'><small class="pull-left">企業オープンコンテスト(rated)</small></button>
+				
+					
+						<button type="submit" class="btn btn-default" data-category="1000"><small class="pull-left">企業コンテスト本番</small></button>
 					
 				
 					
-						<button type="submit" class="btn btn-default category-button-submit" data-category='1002'><small class="pull-left">企業オープンコンテスト(unrated)</small></button>
+						<button type="submit" class="btn btn-default" data-category="1001"><small class="pull-left">企業オープンコンテスト(rated)</small></button>
+					
+				
+					
+						<button type="submit" class="btn btn-default" data-category="1002"><small class="pull-left">企業オープンコンテスト(unrated)</small></button>
 					
 				
 					
@@ -198,19 +201,28 @@
 			</div>
 
 			<hr>
-
-			<p class="filter-body-heading"><span>検索</span></p>
+			<p class="filter-body-heading">検索</p>
 			<div class="form-group">
 				<label for="keyword">コンテスト名</label>
-				<input type="text" class="form-control input-sm" id="keyword" name="keyword" value='' placeholder='キーワード' maxlength="100"
-					   data-toggle='tooltip' data-trigger='focus' title='スペース区切りでキーワードを入力すると、複数のキーワードを指定することができます。'>
+				<input type="text" class="form-control input-sm" id="keyword" name="keyword" value="" placeholder="キーワード" maxlength="100"
+					   data-toggle="tooltip" data-trigger="focus" title="スペース区切りでキーワードを入力すると、複数のキーワードを指定することができます。">
 			</div>
 
 			<button type="submit" class="btn btn-primary btn-sm">検索</button>
-			<a class="btn btn-default btn-sm" href='/contests/archive'>リセット</a>
+			<a class="btn btn-default btn-sm" href="/contests/archive">リセット</a>
 		</form>
 	</div>
 </div>
+<script>
+	$(function() {
+		$('#rated-type-btn-group button').click(function() {
+			$('#collapse-search input[name="ratedType"]').val($(this).data('rated-type'));
+		});
+		$('#category-btn-group button').click(function() {
+			$('#collapse-search input[name="category"]').val($(this).data('category'));
+		});
+	});
+</script>
 	</div>
 	<div class="col-lg-9 col-md-8">
 		<p><span class="h3">過去のコンテスト</span></p>
@@ -219,15 +231,15 @@
 			<div class="text-center">
 	<ul class="pagination pagination-sm mt-0 mb-1">
 		
-			<li class="active"><a href='/contests/archive?lang=ja&amp;page=1'>1</a></li>
+			<li class="active"><a href='/contests/archive?page=1'>1</a></li>
 		
-			<li ><a href='/contests/archive?lang=ja&amp;page=2'>2</a></li>
+			<li ><a href='/contests/archive?page=2'>2</a></li>
 		
-			<li ><a href='/contests/archive?lang=ja&amp;page=4'>4</a></li>
+			<li ><a href='/contests/archive?page=4'>4</a></li>
 		
-			<li ><a href='/contests/archive?lang=ja&amp;page=8'>8</a></li>
+			<li ><a href='/contests/archive?page=8'>8</a></li>
 		
-			<li ><a href='/contests/archive?lang=ja&amp;page=12'>12</a></li>
+			<li ><a href='/contests/archive?page=13'>13</a></li>
 		
 	</ul>
 </div>
@@ -245,353 +257,353 @@
 		<tbody>
 		
 			<tr>
+				<td class="text-center"><a href='http://www.timeanddate.com/worldclock/fixedtime.html?iso=20191013T1300&p1=248' target='blank'><time class='fixtime fixtime-full'>2019-10-13 13:00:00+0900</time></a></td>
+				<td ><span class="">◉</span> <a href='/contests/kupc2019'>Kyoto University Programming Contest 2019</a></td>
+				<td class="text-center">05:00</td>
+				<td class="text-center">-</td>
+			</tr>
+		
+			<tr>
+				<td class="text-center"><a href='http://www.timeanddate.com/worldclock/fixedtime.html?iso=20191005T2100&p1=248' target='blank'><time class='fixtime fixtime-full'>2019-10-05 21:00:00+0900</time></a></td>
+				<td ><span class="user-red">◉</span> <a href='/contests/agc039'>AtCoder Grand Contest 039</a></td>
+				<td class="text-center">02:30</td>
+				<td class="text-center">All</td>
+			</tr>
+		
+			<tr>
+				<td class="text-center"><a href='http://www.timeanddate.com/worldclock/fixedtime.html?iso=20190929T1245&p1=248' target='blank'><time class='fixtime fixtime-full'>2019-09-29 12:45:00+0900</time></a></td>
+				<td ><span class="">◉</span> <a href='/contests/jsc2019-final'>第一回日本最強プログラマー学生選手権決勝</a></td>
+				<td class="text-center">03:00</td>
+				<td class="text-center">-</td>
+			</tr>
+		
+			<tr>
+				<td class="text-center"><a href='http://www.timeanddate.com/worldclock/fixedtime.html?iso=20190929T1245&p1=248' target='blank'><time class='fixtime fixtime-full'>2019-09-29 12:45:00+0900</time></a></td>
+				<td ><span class="">◉</span> <a href='/contests/jsc2019-final-open'>第一回日本最強プログラマー学生選手権決勝(オープンコンテスト)</a></td>
+				<td class="text-center">03:00</td>
+				<td class="text-center">-</td>
+			</tr>
+		
+			<tr>
+				<td class="text-center"><a href='http://www.timeanddate.com/worldclock/fixedtime.html?iso=20190928T2100&p1=248' target='blank'><time class='fixtime fixtime-full'>2019-09-28 21:00:00+0900</time></a></td>
+				<td ><span class="user-blue">◉</span> <a href='/contests/abc142'>AtCoder Beginner Contest 142</a></td>
+				<td class="text-center">01:40</td>
+				<td class="text-center"> ~ 1999</td>
+			</tr>
+		
+			<tr>
+				<td class="text-center"><a href='http://www.timeanddate.com/worldclock/fixedtime.html?iso=20190921T2100&p1=248' target='blank'><time class='fixtime fixtime-full'>2019-09-21 21:00:00+0900</time></a></td>
+				<td ><span class="user-red">◉</span> <a href='/contests/agc038'>AtCoder Grand Contest 038</a></td>
+				<td class="text-center">01:50</td>
+				<td class="text-center">All</td>
+			</tr>
+		
+			<tr>
+				<td class="text-center"><a href='http://www.timeanddate.com/worldclock/fixedtime.html?iso=20190915T2100&p1=248' target='blank'><time class='fixtime fixtime-full'>2019-09-15 21:00:00+0900</time></a></td>
+				<td ><span class="user-blue">◉</span> <a href='/contests/abc141'>AtCoder Beginner Contest 141</a></td>
+				<td class="text-center">01:40</td>
+				<td class="text-center"> ~ 1999</td>
+			</tr>
+		
+			<tr>
+				<td class="text-center"><a href='http://www.timeanddate.com/worldclock/fixedtime.html?iso=20190907T2100&p1=248' target='blank'><time class='fixtime fixtime-full'>2019-09-07 21:00:00+0900</time></a></td>
+				<td ><span class="user-blue">◉</span> <a href='/contests/abc140'>AtCoder Beginner Contest 140</a></td>
+				<td class="text-center">01:40</td>
+				<td class="text-center"> ~ 1999</td>
+			</tr>
+		
+			<tr>
+				<td class="text-center"><a href='http://www.timeanddate.com/worldclock/fixedtime.html?iso=20190901T2100&p1=248' target='blank'><time class='fixtime fixtime-full'>2019-09-01 21:00:00+0900</time></a></td>
+				<td ><span class="user-blue">◉</span> <a href='/contests/abc139'>AtCoder Beginner Contest 139</a></td>
+				<td class="text-center">01:40</td>
+				<td class="text-center"> ~ 1999</td>
+			</tr>
+		
+			<tr>
+				<td class="text-center"><a href='http://www.timeanddate.com/worldclock/fixedtime.html?iso=20190831T2100&p1=248' target='blank'><time class='fixtime fixtime-full'>2019-08-31 21:00:00+0900</time></a></td>
+				<td ><span class="">◉</span> <a href='/contests/chokudai004'>Chokudai Contest 004</a></td>
+				<td class="text-center">02:00</td>
+				<td class="text-center">-</td>
+			</tr>
+		
+			<tr>
+				<td class="text-center"><a href='http://www.timeanddate.com/worldclock/fixedtime.html?iso=20190831T1305&p1=248' target='blank'><time class='fixtime fixtime-full'>2019-08-31 13:05:00+0900</time></a></td>
+				<td ><span class="">◉</span> <a href='/contests/ttpc2019'>東京工業大学プログラミングコンテスト2019</a></td>
+				<td class="text-center">05:00</td>
+				<td class="text-center">-</td>
+			</tr>
+		
+			<tr>
+				<td class="text-center"><a href='http://www.timeanddate.com/worldclock/fixedtime.html?iso=20190824T2100&p1=248' target='blank'><time class='fixtime fixtime-full'>2019-08-24 21:00:00+0900</time></a></td>
+				<td ><span class="user-orange">◉</span> <a href='/contests/jsc2019-qual'>第一回日本最強プログラマー学生選手権-予選-</a></td>
+				<td class="text-center">01:40</td>
+				<td class="text-center"> ~ 2799</td>
+			</tr>
+		
+			<tr>
+				<td class="text-center"><a href='http://www.timeanddate.com/worldclock/fixedtime.html?iso=20190823T1000&p1=248' target='blank'><time class='fixtime fixtime-full'>2019-08-23 10:00:00+0900</time></a></td>
+				<td ><span class="">◉</span> <a href='/contests/asprocon4'>第4回 Asprova プログラミングコンテスト</a></td>
+				<td class="text-center">168:00</td>
+				<td class="text-center">-</td>
+			</tr>
+		
+			<tr>
+				<td class="text-center"><a href='http://www.timeanddate.com/worldclock/fixedtime.html?iso=20190818T2100&p1=248' target='blank'><time class='fixtime fixtime-full'>2019-08-18 21:00:00+0900</time></a></td>
+				<td ><span class="user-blue">◉</span> <a href='/contests/abc138'>AtCoder Beginner Contest 138</a></td>
+				<td class="text-center">01:40</td>
+				<td class="text-center"> ~ 1999</td>
+			</tr>
+		
+			<tr>
+				<td class="text-center"><a href='http://www.timeanddate.com/worldclock/fixedtime.html?iso=20190817T2100&p1=248' target='blank'><time class='fixtime fixtime-full'>2019-08-17 21:00:00+0900</time></a></td>
+				<td ><span class="user-red">◉</span> <a href='/contests/agc037'>AtCoder Grand Contest 037</a></td>
+				<td class="text-center">02:30</td>
+				<td class="text-center">All</td>
+			</tr>
+		
+			<tr>
+				<td class="text-center"><a href='http://www.timeanddate.com/worldclock/fixedtime.html?iso=20190810T2100&p1=248' target='blank'><time class='fixtime fixtime-full'>2019-08-10 21:00:00+0900</time></a></td>
+				<td ><span class="user-blue">◉</span> <a href='/contests/abc137'>AtCoder Beginner Contest 137</a></td>
+				<td class="text-center">01:40</td>
+				<td class="text-center"> ~ 1999</td>
+			</tr>
+		
+			<tr>
+				<td class="text-center"><a href='http://www.timeanddate.com/worldclock/fixedtime.html?iso=20190804T2100&p1=248' target='blank'><time class='fixtime fixtime-full'>2019-08-04 21:00:00+0900</time></a></td>
+				<td ><span class="user-blue">◉</span> <a href='/contests/abc136'>AtCoder Beginner Contest 136</a></td>
+				<td class="text-center">01:40</td>
+				<td class="text-center"> ~ 1999</td>
+			</tr>
+		
+			<tr>
+				<td class="text-center"><a href='http://www.timeanddate.com/worldclock/fixedtime.html?iso=20190803T1000&p1=248' target='blank'><time class='fixtime fixtime-full'>2019-08-03 10:00:00+0900</time></a></td>
+				<td ><span class="">◉</span> <a href='/contests/kuronekoyamato-contest2019'>ヤマト運輸プログラミングコンテスト2019</a></td>
+				<td class="text-center">364:59</td>
+				<td class="text-center">-</td>
+			</tr>
+		
+			<tr>
+				<td class="text-center"><a href='http://www.timeanddate.com/worldclock/fixedtime.html?iso=20190802T1800&p1=248' target='blank'><time class='fixtime fixtime-full'>2019-08-02 18:00:00+0900</time></a></td>
+				<td ><span class="">◉</span> <a href='/contests/otemae2019'>大手前プロコン 2019</a></td>
+				<td class="text-center">03:00</td>
+				<td class="text-center">-</td>
+			</tr>
+		
+			<tr>
+				<td class="text-center"><a href='http://www.timeanddate.com/worldclock/fixedtime.html?iso=20190728T1300&p1=248' target='blank'><time class='fixtime fixtime-full'>2019-07-28 13:00:00+0900</time></a></td>
+				<td ><span class="">◉</span> <a href='/contests/tkppc4-2'>技術室奥プログラミングコンテスト#4 Day2</a></td>
+				<td class="text-center">05:00</td>
+				<td class="text-center">-</td>
+			</tr>
+		
+			<tr>
+				<td class="text-center"><a href='http://www.timeanddate.com/worldclock/fixedtime.html?iso=20190727T2100&p1=248' target='blank'><time class='fixtime fixtime-full'>2019-07-27 21:00:00+0900</time></a></td>
+				<td ><span class="user-blue">◉</span> <a href='/contests/abc135'>AtCoder Beginner Contest 135</a></td>
+				<td class="text-center">01:40</td>
+				<td class="text-center"> ~ 1999</td>
+			</tr>
+		
+			<tr>
+				<td class="text-center"><a href='http://www.timeanddate.com/worldclock/fixedtime.html?iso=20190727T1300&p1=248' target='blank'><time class='fixtime fixtime-full'>2019-07-27 13:00:00+0900</time></a></td>
+				<td ><span class="">◉</span> <a href='/contests/tkppc4-1'>技術室奥プログラミングコンテスト#4 Day1</a></td>
+				<td class="text-center">05:00</td>
+				<td class="text-center">-</td>
+			</tr>
+		
+			<tr>
+				<td class="text-center"><a href='http://www.timeanddate.com/worldclock/fixedtime.html?iso=20190721T2100&p1=248' target='blank'><time class='fixtime fixtime-full'>2019-07-21 21:00:00+0900</time></a></td>
+				<td ><span class="user-red">◉</span> <a href='/contests/agc036'>AtCoder Grand Contest 036</a></td>
+				<td class="text-center">02:40</td>
+				<td class="text-center">All</td>
+			</tr>
+		
+			<tr>
+				<td class="text-center"><a href='http://www.timeanddate.com/worldclock/fixedtime.html?iso=20190720T2100&p1=248' target='blank'><time class='fixtime fixtime-full'>2019-07-20 21:00:00+0900</time></a></td>
+				<td ><span class="user-blue">◉</span> <a href='/contests/abc134'>AtCoder Beginner Contest 134</a></td>
+				<td class="text-center">01:40</td>
+				<td class="text-center"> ~ 1999</td>
+			</tr>
+		
+			<tr>
+				<td class="text-center"><a href='http://www.timeanddate.com/worldclock/fixedtime.html?iso=20190714T2130&p1=248' target='blank'><time class='fixtime fixtime-full'>2019-07-14 21:30:00+0900</time></a></td>
+				<td ><span class="user-red">◉</span> <a href='/contests/agc035'>AtCoder Grand Contest 035</a></td>
+				<td class="text-center">02:10</td>
+				<td class="text-center">All</td>
+			</tr>
+		
+			<tr>
+				<td class="text-center"><a href='http://www.timeanddate.com/worldclock/fixedtime.html?iso=20190707T2100&p1=248' target='blank'><time class='fixtime fixtime-full'>2019-07-07 21:00:00+0900</time></a></td>
+				<td ><span class="user-blue">◉</span> <a href='/contests/abc133'>AtCoder Beginner Contest 133</a></td>
+				<td class="text-center">01:40</td>
+				<td class="text-center"> ~ 1999</td>
+			</tr>
+		
+			<tr>
+				<td class="text-center"><a href='http://www.timeanddate.com/worldclock/fixedtime.html?iso=20190706T1845&p1=248' target='blank'><time class='fixtime fixtime-full'>2019-07-06 18:45:00+0900</time></a></td>
+				<td ><span class="">◉</span> <a href='/contests/bcu30-2019'>プログラミングバトル 本戦 - BCU30</a></td>
+				<td class="text-center">00:20</td>
+				<td class="text-center">-</td>
+			</tr>
+		
+			<tr>
+				<td class="text-center"><a href='http://www.timeanddate.com/worldclock/fixedtime.html?iso=20190706T1415&p1=248' target='blank'><time class='fixtime fixtime-full'>2019-07-06 14:15:00+0900</time></a></td>
+				<td ><span class="">◉</span> <a href='/contests/bcu30-2019-qual'>プログラミングバトル 予選 - BCU30</a></td>
+				<td class="text-center">02:25</td>
+				<td class="text-center">-</td>
+			</tr>
+		
+			<tr>
+				<td class="text-center"><a href='http://www.timeanddate.com/worldclock/fixedtime.html?iso=20190629T2100&p1=248' target='blank'><time class='fixtime fixtime-full'>2019-06-29 21:00:00+0900</time></a></td>
+				<td ><span class="user-blue">◉</span> <a href='/contests/abc132'>AtCoder Beginner Contest 132</a></td>
+				<td class="text-center">01:40</td>
+				<td class="text-center"> ~ 1999</td>
+			</tr>
+		
+			<tr>
+				<td class="text-center"><a href='http://www.timeanddate.com/worldclock/fixedtime.html?iso=20190622T2100&p1=248' target='blank'><time class='fixtime fixtime-full'>2019-06-22 21:00:00+0900</time></a></td>
+				<td ><span class="user-blue">◉</span> <a href='/contests/abc131'>AtCoder Beginner Contest 131</a></td>
+				<td class="text-center">01:40</td>
+				<td class="text-center"> ~ 1999</td>
+			</tr>
+		
+			<tr>
+				<td class="text-center"><a href='http://www.timeanddate.com/worldclock/fixedtime.html?iso=20190616T2100&p1=248' target='blank'><time class='fixtime fixtime-full'>2019-06-16 21:00:00+0900</time></a></td>
+				<td ><span class="user-blue">◉</span> <a href='/contests/abc130'>AtCoder Beginner Contest 130</a></td>
+				<td class="text-center">01:40</td>
+				<td class="text-center"> ~ 1999</td>
+			</tr>
+		
+			<tr>
+				<td class="text-center"><a href='http://www.timeanddate.com/worldclock/fixedtime.html?iso=20190615T2100&p1=248' target='blank'><time class='fixtime fixtime-full'>2019-06-15 21:00:00+0900</time></a></td>
+				<td ><span class="user-orange">◉</span> <a href='/contests/diverta2019-2'>diverta 2019 Programming Contest 2</a></td>
+				<td class="text-center">02:00</td>
+				<td class="text-center"> ~ 2799</td>
+			</tr>
+		
+			<tr>
+				<td class="text-center"><a href='http://www.timeanddate.com/worldclock/fixedtime.html?iso=20190609T2100&p1=248' target='blank'><time class='fixtime fixtime-full'>2019-06-09 21:00:00+0900</time></a></td>
+				<td ><span class="user-blue">◉</span> <a href='/contests/abc129'>AtCoder Beginner Contest 129</a></td>
+				<td class="text-center">01:40</td>
+				<td class="text-center"> ~ 1999</td>
+			</tr>
+		
+			<tr>
 				<td class="text-center"><a href='http://www.timeanddate.com/worldclock/fixedtime.html?iso=20190602T2100&p1=248' target='blank'><time class='fixtime fixtime-full'>2019-06-02 21:00:00+0900</time></a></td>
-				<td ><a href='/contests/agc034'>AtCoder Grand Contest 034</a></td>
+				<td ><span class="user-red">◉</span> <a href='/contests/agc034'>AtCoder Grand Contest 034</a></td>
 				<td class="text-center">02:00</td>
 				<td class="text-center">All</td>
 			</tr>
 		
 			<tr>
 				<td class="text-center"><a href='http://www.timeanddate.com/worldclock/fixedtime.html?iso=20190601T2100&p1=248' target='blank'><time class='fixtime fixtime-full'>2019-06-01 21:00:00+0900</time></a></td>
-				<td ><a href='/contests/m-solutions2019'>M-SOLUTIONS プロコンオープン</a></td>
+				<td ><span class="user-orange">◉</span> <a href='/contests/m-solutions2019'>M-SOLUTIONS プロコンオープン</a></td>
 				<td class="text-center">02:00</td>
 				<td class="text-center"> ~ 2799</td>
 			</tr>
 		
 			<tr>
 				<td class="text-center"><a href='http://www.timeanddate.com/worldclock/fixedtime.html?iso=20190526T2100&p1=248' target='blank'><time class='fixtime fixtime-full'>2019-05-26 21:00:00+0900</time></a></td>
-				<td ><a href='/contests/abc128'>AtCoder Beginner Contest 128</a></td>
+				<td ><span class="user-blue">◉</span> <a href='/contests/abc128'>AtCoder Beginner Contest 128</a></td>
 				<td class="text-center">01:40</td>
 				<td class="text-center"> ~ 1999</td>
 			</tr>
 		
 			<tr>
 				<td class="text-center"><a href='http://www.timeanddate.com/worldclock/fixedtime.html?iso=20190525T2100&p1=248' target='blank'><time class='fixtime fixtime-full'>2019-05-25 21:00:00+0900</time></a></td>
-				<td ><a href='/contests/abc127'>AtCoder Beginner Contest 127</a></td>
+				<td ><span class="user-blue">◉</span> <a href='/contests/abc127'>AtCoder Beginner Contest 127</a></td>
 				<td class="text-center">01:40</td>
 				<td class="text-center"> ~ 1999</td>
 			</tr>
 		
 			<tr>
 				<td class="text-center"><a href='http://www.timeanddate.com/worldclock/fixedtime.html?iso=20190525T1400&p1=248' target='blank'><time class='fixtime fixtime-full'>2019-05-25 14:00:00+0900</time></a></td>
-				<td ><a href='/contests/chokudai_S002'>Chokudai SpeedRun 002</a></td>
+				<td ><span class="">◉</span> <a href='/contests/chokudai_S002'>Chokudai SpeedRun 002</a></td>
 				<td class="text-center">01:00</td>
 				<td class="text-center">-</td>
 			</tr>
 		
 			<tr>
 				<td class="text-center"><a href='http://www.timeanddate.com/worldclock/fixedtime.html?iso=20190519T2100&p1=248' target='blank'><time class='fixtime fixtime-full'>2019-05-19 21:00:00+0900</time></a></td>
-				<td ><a href='/contests/abc126'>AtCoder Beginner Contest 126</a></td>
+				<td ><span class="user-blue">◉</span> <a href='/contests/abc126'>AtCoder Beginner Contest 126</a></td>
 				<td class="text-center">01:40</td>
 				<td class="text-center"> ~ 1999</td>
 			</tr>
 		
 			<tr>
 				<td class="text-center"><a href='http://www.timeanddate.com/worldclock/fixedtime.html?iso=20190511T2115&p1=248' target='blank'><time class='fixtime fixtime-full'>2019-05-11 21:15:00+0900</time></a></td>
-				<td ><a href='/contests/diverta2019'>diverta 2019 Programming Contest</a></td>
+				<td ><span class="user-orange">◉</span> <a href='/contests/diverta2019'>diverta 2019 Programming Contest</a></td>
 				<td class="text-center">02:00</td>
 				<td class="text-center"> ~ 2799</td>
 			</tr>
 		
 			<tr>
-				<td class="text-center"><a href='http://www.timeanddate.com/worldclock/fixedtime.html?iso=20190426T1000&p1=248' target='blank'><time class='fixtime fixtime-full'>2019-04-26 10:00:00+0900</time></a></td>
-				<td ><a href='/contests/asprocon3'>第3回 Asprova プログラミングコンテスト</a></td>
-				<td class="text-center">336:00</td>
-				<td class="text-center">-</td>
-			</tr>
-		
-			<tr>
 				<td class="text-center"><a href='http://www.timeanddate.com/worldclock/fixedtime.html?iso=20190506T1030&p1=248' target='blank'><time class='fixtime fixtime-full'>2019-05-06 10:30:00+0900</time></a></td>
-				<td ><a href='/contests/cpsco2019-s4'>CPSCO2019 Session4</a></td>
+				<td ><span class="">◉</span> <a href='/contests/cpsco2019-s4'>CPSCO2019 Session4</a></td>
 				<td class="text-center">02:00</td>
 				<td class="text-center">-</td>
 			</tr>
 		
 			<tr>
 				<td class="text-center"><a href='http://www.timeanddate.com/worldclock/fixedtime.html?iso=20190505T1400&p1=248' target='blank'><time class='fixtime fixtime-full'>2019-05-05 14:00:00+0900</time></a></td>
-				<td ><a href='/contests/cpsco2019-s3'>CPSCO2019 Session3</a></td>
+				<td ><span class="">◉</span> <a href='/contests/cpsco2019-s3'>CPSCO2019 Session3</a></td>
 				<td class="text-center">02:00</td>
 				<td class="text-center">-</td>
 			</tr>
 		
 			<tr>
 				<td class="text-center"><a href='http://www.timeanddate.com/worldclock/fixedtime.html?iso=20190505T1030&p1=248' target='blank'><time class='fixtime fixtime-full'>2019-05-05 10:30:00+0900</time></a></td>
-				<td ><a href='/contests/cpsco2019-s2'>CPSCO2019 Session2</a></td>
+				<td ><span class="">◉</span> <a href='/contests/cpsco2019-s2'>CPSCO2019 Session2</a></td>
 				<td class="text-center">02:00</td>
 				<td class="text-center">-</td>
 			</tr>
 		
 			<tr>
 				<td class="text-center"><a href='http://www.timeanddate.com/worldclock/fixedtime.html?iso=20190504T2100&p1=248' target='blank'><time class='fixtime fixtime-full'>2019-05-04 21:00:00+0900</time></a></td>
-				<td ><a href='/contests/agc033'>AtCoder Grand Contest 033</a></td>
+				<td ><span class="user-red">◉</span> <a href='/contests/agc033'>AtCoder Grand Contest 033</a></td>
 				<td class="text-center">02:30</td>
 				<td class="text-center">All</td>
 			</tr>
 		
 			<tr>
 				<td class="text-center"><a href='http://www.timeanddate.com/worldclock/fixedtime.html?iso=20190504T1300&p1=248' target='blank'><time class='fixtime fixtime-full'>2019-05-04 13:00:00+0900</time></a></td>
-				<td ><a href='/contests/cpsco2019-s1'>CPSCO2019 Session1</a></td>
+				<td ><span class="">◉</span> <a href='/contests/cpsco2019-s1'>CPSCO2019 Session1</a></td>
 				<td class="text-center">02:30</td>
 				<td class="text-center">-</td>
 			</tr>
 		
 			<tr>
 				<td class="text-center"><a href='http://www.timeanddate.com/worldclock/fixedtime.html?iso=20190503T1900&p1=248' target='blank'><time class='fixtime fixtime-full'>2019-05-03 19:00:00+0900</time></a></td>
-				<td ><a href='/contests/iroha2019-day4'>いろはちゃんコンテスト Day4</a></td>
+				<td ><span class="">◉</span> <a href='/contests/iroha2019-day4'>いろはちゃんコンテスト Day4</a></td>
 				<td class="text-center">05:00</td>
 				<td class="text-center">-</td>
 			</tr>
 		
 			<tr>
 				<td class="text-center"><a href='http://www.timeanddate.com/worldclock/fixedtime.html?iso=20190502T1300&p1=248' target='blank'><time class='fixtime fixtime-full'>2019-05-02 13:00:00+0900</time></a></td>
-				<td ><a href='/contests/iroha2019-day3'>いろはちゃんコンテスト Day3</a></td>
+				<td ><span class="">◉</span> <a href='/contests/iroha2019-day3'>いろはちゃんコンテスト Day3</a></td>
 				<td class="text-center">05:00</td>
 				<td class="text-center">-</td>
 			</tr>
 		
 			<tr>
 				<td class="text-center"><a href='http://www.timeanddate.com/worldclock/fixedtime.html?iso=20190501T1300&p1=248' target='blank'><time class='fixtime fixtime-full'>2019-05-01 13:00:00+0900</time></a></td>
-				<td ><a href='/contests/iroha2019-day2'>いろはちゃんコンテスト Day2</a></td>
+				<td ><span class="">◉</span> <a href='/contests/iroha2019-day2'>いろはちゃんコンテスト Day2</a></td>
 				<td class="text-center">05:00</td>
 				<td class="text-center">-</td>
 			</tr>
 		
 			<tr>
 				<td class="text-center"><a href='http://www.timeanddate.com/worldclock/fixedtime.html?iso=20190430T1300&p1=248' target='blank'><time class='fixtime fixtime-full'>2019-04-30 13:00:00+0900</time></a></td>
-				<td ><a href='/contests/iroha2019-day1'>いろはちゃんコンテスト Day1</a></td>
+				<td ><span class="">◉</span> <a href='/contests/iroha2019-day1'>いろはちゃんコンテスト Day1</a></td>
 				<td class="text-center">05:00</td>
 				<td class="text-center">-</td>
 			</tr>
 		
 			<tr>
 				<td class="text-center"><a href='http://www.timeanddate.com/worldclock/fixedtime.html?iso=20190427T2100&p1=248' target='blank'><time class='fixtime fixtime-full'>2019-04-27 21:00:00+0900</time></a></td>
-				<td ><a href='/contests/abc125'>AtCoder Beginner Contest 125</a></td>
+				<td ><span class="user-green">◉</span> <a href='/contests/abc125'>AtCoder Beginner Contest 125</a></td>
 				<td class="text-center">01:40</td>
 				<td class="text-center"> ~ 1199</td>
-			</tr>
-		
-			<tr>
-				<td class="text-center"><a href='http://www.timeanddate.com/worldclock/fixedtime.html?iso=20190420T2100&p1=248' target='blank'><time class='fixtime fixtime-full'>2019-04-20 21:00:00+0900</time></a></td>
-				<td ><a href='/contests/tenka1-2019-beginner'>Tenka1 Programmer Beginner Contest 2019</a></td>
-				<td class="text-center">01:40</td>
-				<td class="text-center"> ~ 1199</td>
-			</tr>
-		
-			<tr>
-				<td class="text-center"><a href='http://www.timeanddate.com/worldclock/fixedtime.html?iso=20190420T2100&p1=248' target='blank'><time class='fixtime fixtime-full'>2019-04-20 21:00:00+0900</time></a></td>
-				<td ><a href='/contests/tenka1-2019'>Tenka1 Programmer Contest 2019</a></td>
-				<td class="text-center">01:40</td>
-				<td class="text-center"> ~ 2799</td>
-			</tr>
-		
-			<tr>
-				<td class="text-center"><a href='http://www.timeanddate.com/worldclock/fixedtime.html?iso=20190414T2000&p1=248' target='blank'><time class='fixtime fixtime-full'>2019-04-14 20:00:00+0900</time></a></td>
-				<td ><a href='/contests/s8pc-6'>square869120Contest #6</a></td>
-				<td class="text-center">04:00</td>
-				<td class="text-center">-</td>
-			</tr>
-		
-			<tr>
-				<td class="text-center"><a href='http://www.timeanddate.com/worldclock/fixedtime.html?iso=20190413T2100&p1=248' target='blank'><time class='fixtime fixtime-full'>2019-04-13 21:00:00+0900</time></a></td>
-				<td ><a href='/contests/abc124'>AtCoder Beginner Contest 124</a></td>
-				<td class="text-center">01:40</td>
-				<td class="text-center"> ~ 1199</td>
-			</tr>
-		
-			<tr>
-				<td class="text-center"><a href='http://www.timeanddate.com/worldclock/fixedtime.html?iso=20190406T2100&p1=248' target='blank'><time class='fixtime fixtime-full'>2019-04-06 21:00:00+0900</time></a></td>
-				<td ><a href='/contests/abc123'>AtCoder Beginner Contest 123</a></td>
-				<td class="text-center">01:40</td>
-				<td class="text-center"> ~ 1199</td>
-			</tr>
-		
-			<tr>
-				<td class="text-center"><a href='http://www.timeanddate.com/worldclock/fixedtime.html?iso=20190330T2100&p1=248' target='blank'><time class='fixtime fixtime-full'>2019-03-30 21:00:00+0900</time></a></td>
-				<td ><a href='/contests/exawizards2019'>エクサウィザーズ 2019</a></td>
-				<td class="text-center">02:00</td>
-				<td class="text-center"> ~ 2799</td>
-			</tr>
-		
-			<tr>
-				<td class="text-center"><a href='http://www.timeanddate.com/worldclock/fixedtime.html?iso=20190324T2100&p1=248' target='blank'><time class='fixtime fixtime-full'>2019-03-24 21:00:00+0900</time></a></td>
-				<td ><a href='/contests/abc122'>AtCoder Beginner Contest 122</a></td>
-				<td class="text-center">01:40</td>
-				<td class="text-center"> ~ 1199</td>
-			</tr>
-		
-			<tr>
-				<td class="text-center"><a href='http://www.timeanddate.com/worldclock/fixedtime.html?iso=20190323T2200&p1=248' target='blank'><time class='fixtime fixtime-full'>2019-03-23 22:00:00+0900</time></a></td>
-				<td ><a href='/contests/agc032'>AtCoder Grand Contest 032</a></td>
-				<td class="text-center">01:50</td>
-				<td class="text-center">All</td>
-			</tr>
-		
-			<tr>
-				<td class="text-center"><a href='http://www.timeanddate.com/worldclock/fixedtime.html?iso=20190323T1300&p1=248' target='blank'><time class='fixtime fixtime-full'>2019-03-23 13:00:00+0900</time></a></td>
-				<td ><a href='/contests/caddi2019'>CADDi 2019</a></td>
-				<td class="text-center">08:00</td>
-				<td class="text-center">-</td>
-			</tr>
-		
-			<tr>
-				<td class="text-center"><a href='http://www.timeanddate.com/worldclock/fixedtime.html?iso=20190316T2100&p1=248' target='blank'><time class='fixtime fixtime-full'>2019-03-16 21:00:00+0900</time></a></td>
-				<td ><a href='/contests/agc031'>AtCoder Grand Contest 031</a></td>
-				<td class="text-center">02:40</td>
-				<td class="text-center">All</td>
-			</tr>
-		
-			<tr>
-				<td class="text-center"><a href='http://www.timeanddate.com/worldclock/fixedtime.html?iso=20190310T1300&p1=248' target='blank'><time class='fixtime fixtime-full'>2019-03-10 13:00:00+0900</time></a></td>
-				<td ><a href='/contests/wupc2019'>早稲田大学プログラミングコンテスト2019</a></td>
-				<td class="text-center">04:00</td>
-				<td class="text-center">-</td>
-			</tr>
-		
-			<tr>
-				<td class="text-center"><a href='http://www.timeanddate.com/worldclock/fixedtime.html?iso=20190309T2100&p1=248' target='blank'><time class='fixtime fixtime-full'>2019-03-09 21:00:00+0900</time></a></td>
-				<td ><a href='/contests/abc121'>AtCoder Beginner Contest 121</a></td>
-				<td class="text-center">01:40</td>
-				<td class="text-center"> ~ 1199</td>
-			</tr>
-		
-			<tr>
-				<td class="text-center"><a href='http://www.timeanddate.com/worldclock/fixedtime.html?iso=20190303T2100&p1=248' target='blank'><time class='fixtime fixtime-full'>2019-03-03 21:00:00+0900</time></a></td>
-				<td ><a href='/contests/abc120'>AtCoder Beginner Contest 120</a></td>
-				<td class="text-center">01:40</td>
-				<td class="text-center"> ~ 1199</td>
-			</tr>
-		
-			<tr>
-				<td class="text-center"><a href='http://www.timeanddate.com/worldclock/fixedtime.html?iso=20190302T1400&p1=248' target='blank'><time class='fixtime fixtime-full'>2019-03-02 14:00:00+0900</time></a></td>
-				<td ><a href='/contests/rco-contest-2019-final-open'>第3回 RCO日本橋ハーフマラソン 本戦 (オープン)</a></td>
-				<td class="text-center">04:00</td>
-				<td class="text-center">-</td>
-			</tr>
-		
-			<tr>
-				<td class="text-center"><a href='http://www.timeanddate.com/worldclock/fixedtime.html?iso=20190302T1400&p1=248' target='blank'><time class='fixtime fixtime-full'>2019-03-02 14:00:00+0900</time></a></td>
-				<td ><a href='/contests/rco-contest-2019-final'>第3回 RCO日本橋ハーフマラソン 本戦</a></td>
-				<td class="text-center">04:00</td>
-				<td class="text-center">-</td>
-			</tr>
-		
-			<tr>
-				<td class="text-center"><a href='http://www.timeanddate.com/worldclock/fixedtime.html?iso=20190214T0000&p1=248' target='blank'><time class='fixtime fixtime-full'>2019-02-14 00:00:00+0900</time></a></td>
-				<td ><a href='/contests/hokudai-hitachi2018'>北大・日立新概念コンピューティングコンテスト2018</a></td>
-				<td class="text-center">335:59</td>
-				<td class="text-center">-</td>
-			</tr>
-		
-			<tr>
-				<td class="text-center"><a href='http://www.timeanddate.com/worldclock/fixedtime.html?iso=20190224T2100&p1=248' target='blank'><time class='fixtime fixtime-full'>2019-02-24 21:00:00+0900</time></a></td>
-				<td ><a href='/contests/abc119'>AtCoder Beginner Contest 119</a></td>
-				<td class="text-center">01:40</td>
-				<td class="text-center"> ~ 1199</td>
-			</tr>
-		
-			<tr>
-				<td class="text-center"><a href='http://www.timeanddate.com/worldclock/fixedtime.html?iso=20190223T2300&p1=248' target='blank'><time class='fixtime fixtime-full'>2019-02-23 23:00:00+0900</time></a></td>
-				<td ><a href='/contests/wtf19-open'>World Tour Finals 2019 Open Contest</a></td>
-				<td class="text-center">04:00</td>
-				<td class="text-center">-</td>
-			</tr>
-		
-			<tr>
-				<td class="text-center"><a href='http://www.timeanddate.com/worldclock/fixedtime.html?iso=20190223T1350&p1=248' target='blank'><time class='fixtime fixtime-full'>2019-02-23 13:50:00+0900</time></a></td>
-				<td ><a href='/contests/yahoo-procon2019-final-open'>「みんなのプロコン 2019」決勝 オープンコンテスト</a></td>
-				<td class="text-center">02:00</td>
-				<td class="text-center">-</td>
-			</tr>
-		
-			<tr>
-				<td class="text-center"><a href='http://www.timeanddate.com/worldclock/fixedtime.html?iso=20190223T1350&p1=248' target='blank'><time class='fixtime fixtime-full'>2019-02-23 13:50:00+0900</time></a></td>
-				<td ><a href='/contests/yahoo-procon2019-final'>「みんなのプロコン 2019」決勝</a></td>
-				<td class="text-center">02:00</td>
-				<td class="text-center">-</td>
-			</tr>
-		
-			<tr>
-				<td class="text-center"><a href='http://www.timeanddate.com/worldclock/fixedtime.html?iso=20190221T1100&p1=248' target='blank'><time class='fixtime fixtime-full'>2019-02-21 11:00:00+0900</time></a></td>
-				<td ><a href='/contests/wtf19'>World Tour Finals 2019</a></td>
-				<td class="text-center">04:00</td>
-				<td class="text-center">All</td>
-			</tr>
-		
-			<tr>
-				<td class="text-center"><a href='http://www.timeanddate.com/worldclock/fixedtime.html?iso=20190217T1722&p1=248' target='blank'><time class='fixtime fixtime-full'>2019-02-17 17:22:00+0900</time></a></td>
-				<td ><a href='/contests/nikkei2019-ex'>全国統一プログラミング王決定戦 エキシビジョン</a></td>
-				<td class="text-center">00:20</td>
-				<td class="text-center">-</td>
-			</tr>
-		
-			<tr>
-				<td class="text-center"><a href='http://www.timeanddate.com/worldclock/fixedtime.html?iso=20190217T1245&p1=248' target='blank'><time class='fixtime fixtime-full'>2019-02-17 12:45:00+0900</time></a></td>
-				<td ><a href='/contests/nikkei2019-final'>全国統一プログラミング王決定戦本戦</a></td>
-				<td class="text-center">03:00</td>
-				<td class="text-center">-</td>
-			</tr>
-		
-			<tr>
-				<td class="text-center"><a href='http://www.timeanddate.com/worldclock/fixedtime.html?iso=20190216T2100&p1=248' target='blank'><time class='fixtime fixtime-full'>2019-02-16 21:00:00+0900</time></a></td>
-				<td ><a href='/contests/abc118'>AtCoder Beginner Contest 118</a></td>
-				<td class="text-center">01:40</td>
-				<td class="text-center"> ~ 1199</td>
-			</tr>
-		
-			<tr>
-				<td class="text-center"><a href='http://www.timeanddate.com/worldclock/fixedtime.html?iso=20190211T1900&p1=248' target='blank'><time class='fixtime fixtime-full'>2019-02-11 19:00:00+0900</time></a></td>
-				<td ><a href='/contests/rco-contest-2019-qual'>第3回 RCO日本橋ハーフマラソン 予選</a></td>
-				<td class="text-center">04:00</td>
-				<td class="text-center">-</td>
-			</tr>
-		
-			<tr>
-				<td class="text-center"><a href='http://www.timeanddate.com/worldclock/fixedtime.html?iso=20190209T2100&p1=248' target='blank'><time class='fixtime fixtime-full'>2019-02-09 21:00:00+0900</time></a></td>
-				<td ><a href='/contests/yahoo-procon2019-qual'>「みんなのプロコン 2019」</a></td>
-				<td class="text-center">02:00</td>
-				<td class="text-center"> ~ 2799</td>
-			</tr>
-		
-			<tr>
-				<td class="text-center"><a href='http://www.timeanddate.com/worldclock/fixedtime.html?iso=20190203T2100&p1=248' target='blank'><time class='fixtime fixtime-full'>2019-02-03 21:00:00+0900</time></a></td>
-				<td ><a href='/contests/abc117'>AtCoder Beginner Contest 117</a></td>
-				<td class="text-center">01:40</td>
-				<td class="text-center"> ~ 1199</td>
-			</tr>
-		
-			<tr>
-				<td class="text-center"><a href='http://www.timeanddate.com/worldclock/fixedtime.html?iso=20190127T2100&p1=248' target='blank'><time class='fixtime fixtime-full'>2019-01-27 21:00:00+0900</time></a></td>
-				<td ><a href='/contests/nikkei2019-qual'>全国統一プログラミング王決定戦予選</a></td>
-				<td class="text-center">02:00</td>
-				<td class="text-center"> ~ 2799</td>
-			</tr>
-		
-			<tr>
-				<td class="text-center"><a href='http://www.timeanddate.com/worldclock/fixedtime.html?iso=20190120T2100&p1=248' target='blank'><time class='fixtime fixtime-full'>2019-01-20 21:00:00+0900</time></a></td>
-				<td ><a href='/contests/abc116'>AtCoder Beginner Contest 116</a></td>
-				<td class="text-center">01:40</td>
-				<td class="text-center"> ~ 1199</td>
-			</tr>
-		
-			<tr>
-				<td class="text-center"><a href='http://www.timeanddate.com/worldclock/fixedtime.html?iso=20190119T1010&p1=248' target='blank'><time class='fixtime fixtime-full'>2019-01-19 10:10:00+0900</time></a></td>
-				<td ><a href='/contests/ddcc2019-final'>DISCO presents ディスカバリーチャンネル コードコンテスト2019 本戦</a></td>
-				<td class="text-center">02:00</td>
-				<td class="text-center">-</td>
-			</tr>
-		
-			<tr>
-				<td class="text-center"><a href='http://www.timeanddate.com/worldclock/fixedtime.html?iso=20190113T2100&p1=248' target='blank'><time class='fixtime fixtime-full'>2019-01-13 21:00:00+0900</time></a></td>
-				<td ><a href='/contests/keyence2019'>キーエンス プログラミング コンテスト 2019</a></td>
-				<td class="text-center">02:00</td>
-				<td class="text-center"> ~ 2799</td>
-			</tr>
-		
-			<tr>
-				<td class="text-center"><a href='http://www.timeanddate.com/worldclock/fixedtime.html?iso=20190112T2100&p1=248' target='blank'><time class='fixtime fixtime-full'>2019-01-12 21:00:00+0900</time></a></td>
-				<td ><a href='/contests/aising2019'>エイシング プログラミング コンテスト 2019</a></td>
-				<td class="text-center">02:00</td>
-				<td class="text-center"> ~ 1999</td>
 			</tr>
 		
 		</tbody>
@@ -600,15 +612,15 @@
 			<div class="text-center">
 	<ul class="pagination pagination-sm mt-0 mb-1">
 		
-			<li class="active"><a href='/contests/archive?lang=ja&amp;page=1'>1</a></li>
+			<li class="active"><a href='/contests/archive?page=1'>1</a></li>
 		
-			<li ><a href='/contests/archive?lang=ja&amp;page=2'>2</a></li>
+			<li ><a href='/contests/archive?page=2'>2</a></li>
 		
-			<li ><a href='/contests/archive?lang=ja&amp;page=4'>4</a></li>
+			<li ><a href='/contests/archive?page=4'>4</a></li>
 		
-			<li ><a href='/contests/archive?lang=ja&amp;page=8'>8</a></li>
+			<li ><a href='/contests/archive?page=8'>8</a></li>
 		
-			<li ><a href='/contests/archive?lang=ja&amp;page=12'>12</a></li>
+			<li ><a href='/contests/archive?page=13'>13</a></li>
 		
 	</ul>
 </div>
@@ -622,7 +634,7 @@
 			
 			
 			
-<div class="a2a_kit a2a_kit_size_20 a2a_default_style pull-right" data-a2a-url="https://atcoder.jp/contests/archive?lang=ja&amp;page=1" data-a2a-title="過去のコンテスト - AtCoder">
+<div class="a2a_kit a2a_kit_size_20 a2a_default_style pull-right" data-a2a-url="https://atcoder.jp/contests/archive?lang=ja" data-a2a-title="過去のコンテスト - AtCoder">
 	<a class="a2a_button_facebook"></a>
 	<a class="a2a_button_twitter"></a>
 	
@@ -637,7 +649,7 @@
 	</div> 
 	<hr>
 </div> 
-<div class="container">
+<div class="container" style="margin-bottom: 80px;">
     <footer class="footer">
 		
 		<ul>
@@ -660,4 +672,5 @@
 
 </body>
 </html>
+
 


### PR DESCRIPTION
AtCoder側のアップデートにより、「過去のコンテスト」ページ (https://atcoder.jp/contests/archive) のコンテスト名の欄に
```
<span class>◉</span>
```
が追加されました。
これによって、コンテスト名が"◉"と解析されてしまうバグを修正したプルリクです。